### PR TITLE
Fix _.last() bug in invokeQueue chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,12 +136,14 @@
 
   function getDependencies(module, name) {
     var invokeQueue = angular.module(module)._invokeQueue;
-    return _.chain(invokeQueue)
+    // depArr is an array-like object
+    // it has no length property
+    var depArr = _.chain(invokeQueue)
       .unzip().last()
       .find(function (config) {
         return _.isEqual(config[0], name);
-      })
-      .last().initial().value();
+      }).value();
+    return _.initial(depArr[1]);
   }
 
   function provideValue(mock, dependency) {


### PR DESCRIPTION
Fix bug where angular invokeQueue has an array-like object that broke _.last()
